### PR TITLE
Catch could not find file errors

### DIFF
--- a/Tests/OutputClassifierTests.cs
+++ b/Tests/OutputClassifierTests.cs
@@ -53,6 +53,7 @@ namespace Tests
         [TestCase("Information:", ClassificationTypeDefinitions.LogInfo)]
         [TestCase(" 0 Warning(s)", ClassificationTypeDefinitions.BuildHead)]
         [TestCase(" 0 Error(s)", ClassificationTypeDefinitions.BuildHead)]
+        [TestCase("Could not find file", ClassificationTypeDefinitions.BuildHead)]
         public void GetClassificationSpansFromSnapShot(string pattern, string classification)
         {
             Settings.Load();

--- a/VSColorOutput/State/Settings.cs
+++ b/VSColorOutput/State/Settings.cs
@@ -194,6 +194,12 @@ namespace VSColorOutput.State
                     RegExPattern = @"(\W|^)information\W",
                     ClassificationType = ClassificationTypes.LogInformation,
                     IgnoreCase = true
+                },
+                new RegExClassification
+                {
+                    RegExPattern = @"Could not find file",
+                    ClassificationType = ClassificationTypes.LogError,
+                    IgnoreCase = true
                 }
             };
         }


### PR DESCRIPTION
There is annoying error which not being highlighted:

```
11>: Build (web): Could not find file 'C:\Sample\bin\roslyn\csc.exe'.
```

In huge solutions it is pretty easy to miss it