### PR TITLE
fix wrong test case

### DIFF
--- a/Tests/OutputClassifierTests.cs
+++ b/Tests/OutputClassifierTests.cs
@@ -53,7 +53,7 @@ namespace Tests
         [TestCase("Information:", ClassificationTypeDefinitions.LogInfo)]
         [TestCase(" 0 Warning(s)", ClassificationTypeDefinitions.BuildHead)]
         [TestCase(" 0 Error(s)", ClassificationTypeDefinitions.BuildHead)]
-        [TestCase("Could not find file", ClassificationTypeDefinitions.BuildHead)]
+        [TestCase("Could not find file", ClassificationTypeDefinitions.LogError)]
         public void GetClassificationSpansFromSnapShot(string pattern, string classification)
         {
             Settings.Load();


### PR DESCRIPTION
By mistake I have commited wrong testcase, did figure it out while were fighting with AppVeyor which by the way I was able to run successfull

https://ci.appveyor.com/project/mac2000/vscoloroutput


May you try to go to *Build \ Settings* and add `nuget restore` to *Before build cmd script* - that helps me