### PR TITLE
Added ignore for "error-" to the base settings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+/.vs

--- a/VSColorOutput/State/Settings.cs
+++ b/VSColorOutput/State/Settings.cs
@@ -167,7 +167,7 @@ namespace VSColorOutput.State
                 },
                 new RegExClassification
                 {
-                    RegExPattern = @"(\W|^)^(?!.*warning\s(BC|CS)\d+:).*(error|fail|failed|exception)[^\w\.]",
+                    RegExPattern = @"(\W|^)^(?!.*warning\s(BC|CS)\d+:).*(error|fail|failed|exception)[^\w\.-]",
                     ClassificationType = ClassificationTypes.LogError,
                     IgnoreCase = true
                 },


### PR DESCRIPTION
When building SQL Server database projects the command line option "/warnaserror-" was being flagged as an error.