### PR TITLE
Added support for Visual Studio 2019

### DIFF
--- a/VSColorOutput/source.extension.vsixmanifest
+++ b/VSColorOutput/source.extension.vsixmanifest
@@ -11,9 +11,7 @@
     <Tags>Build, Open Source, Productivity, Extension, Color, Output, Output Coloring</Tags>
   </Metadata>
   <Installation>
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Pro" />
-    <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Enterprise" />
+    <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -22,7 +20,7 @@
     <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
   </Assets>
   <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.25904.2,16.0)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,)" DisplayName="Visual Studio core editor" />
   </Prerequisites>
 </PackageManifest>
 


### PR DESCRIPTION
Here's what I did:

* Updated `InstallationTarget` version range to include VS 2019 (16.0)
* Removed redundant `InstallationTargets` (`Pro` and `Enterprise`) since `Community` covers them both
* Made dependency on CoreEditor open ended with a minimum version of 15.0

If you have any questions, please let me know.

When/if you take these changes and uploads the new version to the Marketplace, don't be alarmed that the Marketplace doesn't yet show that the extension supports VS 2019. Please upload regardless.


Mads Kristensen
Visual Studio Extensibility Team