### PR TITLE
Trailing Plus Sign Flagged As Error Fix and Code Analysis Warnings As Error Fix

### DIFF
--- a/VSColorOutput/State/Settings.cs
+++ b/VSColorOutput/State/Settings.cs
@@ -167,7 +167,7 @@ namespace VSColorOutput.State
                 },
                 new RegExClassification
                 {
-                    RegExPattern = @"(\W|^)^(?!.*warning\s(BC|CS)\d+:).*(error|fail|failed|exception)[^\w\.-]",
+                    RegExPattern = @"(\W|^)^(?!.*warning\s(BC|CS)\d+:).*(error|fail|failed|exception)[^\w\.\-\+]",
                     ClassificationType = ClassificationTypes.LogError,
                     IgnoreCase = true
                 },

--- a/VSColorOutput/State/Settings.cs
+++ b/VSColorOutput/State/Settings.cs
@@ -167,7 +167,7 @@ namespace VSColorOutput.State
                 },
                 new RegExClassification
                 {
-                    RegExPattern = @"(\W|^)^(?!.*warning\s(BC|CS)\d+:).*(error|fail|failed|exception)[^\w\.\-\+]",
+                    RegExPattern = @"(\W|^)^(?!.*warning\s(BC|CS|CA)\d+:).*(error|fail|failed|exception)[^\w\.\-\+]",
                     ClassificationType = ClassificationTypes.LogError,
                     IgnoreCase = true
                 },


### PR DESCRIPTION
This is similar to #75 but we have /warnaserror+ turned on for our builds, and the current code flags the entire compile command as an error.

I also escaped the current code's minus sign to not be interpreted as a range so I could add the plus sign. I escaped the plus sign as well mainly for code readability.

Finally, when running code analysis ([see here for examples](https://docs.microsoft.com/en-us/visualstudio/code-quality/code-analysis-warnings-for-managed-code-by-checkid?view=vs-2017)) warnings can start with the CA prefix. I added that to the same regex.