### PR TITLE
ElapsedBuildTime is now aware of the current culture, variables renamed, newline adaptions, c# 6/7

### DIFF
--- a/VSColorOutput.Tests/BuildEventsTests.cs
+++ b/VSColorOutput.Tests/BuildEventsTests.cs
@@ -135,7 +135,7 @@ namespace Tests
             mockOutputWindow.SetupGet(o => o.OutputWindowPanes).Returns(mockOutputWindowPanes.Object);
             mockOutputWindowPane.SetupGet(op => op.Guid).Returns(VSConstants.OutputWindowPaneGuid.BuildOutputPane_string);
             mockOutputWindowPane.Setup(op => op.OutputString(It.Is<string>(s => s == $"{Environment.NewLine}Projects build report:{Environment.NewLine}")));
-						mockOutputWindowPane.Setup(op => op.OutputString(It.Is<string>(s => s == $"  Succeeded | test.proj [Debug|Any CPU]{Environment.NewLine}")));
+            mockOutputWindowPane.Setup(op => op.OutputString(It.Is<string>(s => s == $"  Succeeded | test.proj [Debug|Any CPU]{Environment.NewLine}")));
             mockOutputWindowPane.Setup(op => op.OutputString(It.Is<string>(s => s == $"  Failed    | test2.proj [Release|Any CPU]{Environment.NewLine}")));
             var panes = new[] { mockOutputWindowPane.Object };
             mockOutputWindowPanes.Setup(op => op.GetEnumerator()).Returns(panes.GetEnumerator());

--- a/VSColorOutput.Tests/BuildEventsTests.cs
+++ b/VSColorOutput.Tests/BuildEventsTests.cs
@@ -134,9 +134,9 @@ namespace Tests
             mockToolWindows.SetupGet(t => t.OutputWindow).Returns(mockOutputWindow.Object);
             mockOutputWindow.SetupGet(o => o.OutputWindowPanes).Returns(mockOutputWindowPanes.Object);
             mockOutputWindowPane.SetupGet(op => op.Guid).Returns(VSConstants.OutputWindowPaneGuid.BuildOutputPane_string);
-            mockOutputWindowPane.Setup(op => op.OutputString(It.Is<string>(s => s == "\r\nProjects build report:\r\n")));
-            mockOutputWindowPane.Setup(op => op.OutputString(It.Is<string>(s => s == "  Succeeded | test.proj [Debug|Any CPU]\r\n")));
-            mockOutputWindowPane.Setup(op => op.OutputString(It.Is<string>(s => s == "  Failed    | test2.proj [Release|Any CPU]\r\n")));
+            mockOutputWindowPane.Setup(op => op.OutputString(It.Is<string>(s => s == $"{Environment.NewLine}Projects build report:{Environment.NewLine}")));
+						mockOutputWindowPane.Setup(op => op.OutputString(It.Is<string>(s => s == $"  Succeeded | test.proj [Debug|Any CPU]{Environment.NewLine}")));
+            mockOutputWindowPane.Setup(op => op.OutputString(It.Is<string>(s => s == $"  Failed    | test2.proj [Release|Any CPU]{Environment.NewLine}")));
             var panes = new[] { mockOutputWindowPane.Object };
             mockOutputWindowPanes.Setup(op => op.GetEnumerator()).Returns(panes.GetEnumerator());
             mockEvents.SetupGet(e => e.DTEEvents).Returns(mockDteEvents.Object);

--- a/VSColorOutput.Tests/FakeClassificationType.cs
+++ b/VSColorOutput.Tests/FakeClassificationType.cs
@@ -6,15 +6,15 @@ namespace Tests
 {
     public class FakeClassificationType : IClassificationType
     {
-				public FakeClassificationType(string classification) => Classification = classification;
+        public FakeClassificationType(string classification) => Classification = classification;
 
-				public bool IsOfType(string type)
+        public bool IsOfType(string type)
         {
             return false;
         }
 
         public string Classification { get; private set; }
 
-				public IEnumerable<IClassificationType> BaseTypes => Enumerable.Empty<IClassificationType>();
-	}
+        public IEnumerable<IClassificationType> BaseTypes => Enumerable.Empty<IClassificationType>();
+  }
 }

--- a/VSColorOutput.Tests/FakeClassificationType.cs
+++ b/VSColorOutput.Tests/FakeClassificationType.cs
@@ -6,21 +6,15 @@ namespace Tests
 {
     public class FakeClassificationType : IClassificationType
     {
-        public FakeClassificationType(string classification)
-        {
-            Classification = classification;
-        }
+				public FakeClassificationType(string classification) => Classification = classification;
 
-        public bool IsOfType(string type)
+				public bool IsOfType(string type)
         {
             return false;
         }
 
         public string Classification { get; private set; }
 
-        public IEnumerable<IClassificationType> BaseTypes
-        {
-            get { return Enumerable.Empty<IClassificationType>(); }
-        }
-    }
+				public IEnumerable<IClassificationType> BaseTypes => Enumerable.Empty<IClassificationType>();
+	}
 }

--- a/VSColorOutput.Tests/FakeTextSnapshot.cs
+++ b/VSColorOutput.Tests/FakeTextSnapshot.cs
@@ -76,22 +76,13 @@ namespace Tests
             return position;
         }
 
-        public int Length
-        {
-            get { return _text.Length; }
-        }
+				public int Length => _text.Length;
 
-        public int LineCount
-        {
-            get { return _lines.Length; }
-        }
+				public int LineCount => _lines.Length;
 
-        public char this[int position]
-        {
-            get { return _text[position]; }
-        }
+				public char this[int position] => _text[position];
 
-        public IEnumerable<ITextSnapshotLine> Lines { get; }
+				public IEnumerable<ITextSnapshotLine> Lines { get; }
         public ITextBuffer TextBuffer { get; }
         public ITextVersion Version { get; }
 
@@ -150,12 +141,9 @@ namespace Tests
         // Only here so that ToString will work in SnapshotSpan for debugging
         private class FakeTextBuffer : ITextBuffer
         {
-            public FakeTextBuffer()
-            {
-                Properties = new PropertyCollection();
-            }
+						public FakeTextBuffer() => Properties = new PropertyCollection();
 
-            public PropertyCollection Properties { get; }
+						public PropertyCollection Properties { get; }
 
             public ITextEdit CreateEdit(EditOptions options, int? reiteratedVersionNumber, object editTag)
             {
@@ -255,12 +243,9 @@ namespace Tests
 
         private class FakeVersion : ITextVersion
         {
-            public FakeVersion(int versionNumber)
-            {
-                VersionNumber = versionNumber;
-            }
+						public FakeVersion(int versionNumber) => VersionNumber = versionNumber;
 
-            public ITrackingPoint CreateTrackingPoint(int position, PointTrackingMode trackingMode)
+						public ITrackingPoint CreateTrackingPoint(int position, PointTrackingMode trackingMode)
             {
                 throw new NotImplementedException();
             }

--- a/VSColorOutput.Tests/FakeTextSnapshot.cs
+++ b/VSColorOutput.Tests/FakeTextSnapshot.cs
@@ -76,13 +76,13 @@ namespace Tests
             return position;
         }
 
-				public int Length => _text.Length;
+        public int Length => _text.Length;
 
-				public int LineCount => _lines.Length;
+        public int LineCount => _lines.Length;
 
-				public char this[int position] => _text[position];
+        public char this[int position] => _text[position];
 
-				public IEnumerable<ITextSnapshotLine> Lines { get; }
+        public IEnumerable<ITextSnapshotLine> Lines { get; }
         public ITextBuffer TextBuffer { get; }
         public ITextVersion Version { get; }
 
@@ -141,9 +141,9 @@ namespace Tests
         // Only here so that ToString will work in SnapshotSpan for debugging
         private class FakeTextBuffer : ITextBuffer
         {
-						public FakeTextBuffer() => Properties = new PropertyCollection();
+            public FakeTextBuffer() => Properties = new PropertyCollection();
 
-						public PropertyCollection Properties { get; }
+            public PropertyCollection Properties { get; }
 
             public ITextEdit CreateEdit(EditOptions options, int? reiteratedVersionNumber, object editTag)
             {
@@ -243,9 +243,9 @@ namespace Tests
 
         private class FakeVersion : ITextVersion
         {
-						public FakeVersion(int versionNumber) => VersionNumber = versionNumber;
+            public FakeVersion(int versionNumber) => VersionNumber = versionNumber;
 
-						public ITrackingPoint CreateTrackingPoint(int position, PointTrackingMode trackingMode)
+            public ITrackingPoint CreateTrackingPoint(int position, PointTrackingMode trackingMode)
             {
                 throw new NotImplementedException();
             }

--- a/VSColorOutput.Tests/FakeTextSnapshotLine.cs
+++ b/VSColorOutput.Tests/FakeTextSnapshotLine.cs
@@ -46,29 +46,14 @@ namespace Tests
 
         public SnapshotPoint Start { get; }
 
-        public int Length
-        {
-            get { return _text.Length; }
-        }
+				public int Length => _text.Length;
 
-        public int LengthIncludingLineBreak
-        {
-            get { return _text.Length + LineBreakLength; }
-        }
+				public int LengthIncludingLineBreak => _text.Length + LineBreakLength;
 
-        public SnapshotPoint End
-        {
-            get { return Start + Length; }
-        }
+				public SnapshotPoint End => Start + Length;
 
-        public SnapshotPoint EndIncludingLineBreak
-        {
-            get { return Start + LengthIncludingLineBreak; }
-        }
+				public SnapshotPoint EndIncludingLineBreak => Start + LengthIncludingLineBreak;
 
-        public int LineBreakLength
-        {
-            get { return Environment.NewLine.Length; }
-        }
-    }
+				public int LineBreakLength => Environment.NewLine.Length;
+	}
 }

--- a/VSColorOutput.Tests/FakeTextSnapshotLine.cs
+++ b/VSColorOutput.Tests/FakeTextSnapshotLine.cs
@@ -46,14 +46,14 @@ namespace Tests
 
         public SnapshotPoint Start { get; }
 
-				public int Length => _text.Length;
+        public int Length => _text.Length;
 
-				public int LengthIncludingLineBreak => _text.Length + LineBreakLength;
+        public int LengthIncludingLineBreak => _text.Length + LineBreakLength;
 
-				public SnapshotPoint End => Start + Length;
+        public SnapshotPoint End => Start + Length;
 
-				public SnapshotPoint EndIncludingLineBreak => Start + LengthIncludingLineBreak;
+        public SnapshotPoint EndIncludingLineBreak => Start + LengthIncludingLineBreak;
 
-				public int LineBreakLength => Environment.NewLine.Length;
-	}
+        public int LineBreakLength => Environment.NewLine.Length;
+  }
 }

--- a/VSColorOutput/FindResults/FindResultsClassifier.cs
+++ b/VSColorOutput/FindResults/FindResultsClassifier.cs
@@ -30,12 +30,9 @@ namespace VSColorOutput.FindResults
 
         public bool HighlightFindResults { get; set; }
 
-        static FindResultsClassifier()
-        {
-            FilenameRegex = new Regex(@"^\s*.[:\\]\\.*\(\d+\):", RegexOptions.Compiled);
-        }
+				static FindResultsClassifier() => FilenameRegex = new Regex(@"^\s*.[:\\]\\.*\(\d+\):", RegexOptions.Compiled);
 
-        public void Initialize(IClassificationTypeRegistryService classificationRegistry, IClassificationFormatMapService formatMapService)
+				public void Initialize(IClassificationTypeRegistryService classificationRegistry, IClassificationFormatMapService formatMapService)
         {
             if (Interlocked.CompareExchange(ref _initialized, 1, 0) == 1) return;
 

--- a/VSColorOutput/FindResults/FindResultsClassifier.cs
+++ b/VSColorOutput/FindResults/FindResultsClassifier.cs
@@ -30,9 +30,9 @@ namespace VSColorOutput.FindResults
 
         public bool HighlightFindResults { get; set; }
 
-				static FindResultsClassifier() => FilenameRegex = new Regex(@"^\s*.[:\\]\\.*\(\d+\):", RegexOptions.Compiled);
+        static FindResultsClassifier() => FilenameRegex = new Regex(@"^\s*.[:\\]\\.*\(\d+\):", RegexOptions.Compiled);
 
-				public void Initialize(IClassificationTypeRegistryService classificationRegistry, IClassificationFormatMapService formatMapService)
+        public void Initialize(IClassificationTypeRegistryService classificationRegistry, IClassificationFormatMapService formatMapService)
         {
             if (Interlocked.CompareExchange(ref _initialized, 1, 0) == 1) return;
 

--- a/VSColorOutput/Output/BuildEvents/BuildEvents.cs
+++ b/VSColorOutput/Output/BuildEvents/BuildEvents.cs
@@ -137,7 +137,7 @@ namespace VSColorOutput.Output.BuildEvents
 
             if (ShowBuildReport)
             {
-								_projectsBuildReport.Add("  " + (success ? "Succeeded" : "Failed   ") + $" | {project} [{projectConfig}|{platform}]");
+                _projectsBuildReport.Add("  " + (success ? "Succeeded" : "Failed   ") + $" | {project} [{projectConfig}|{platform}]");
             }
         }
 

--- a/VSColorOutput/Output/BuildEvents/BuildEvents.cs
+++ b/VSColorOutput/Output/BuildEvents/BuildEvents.cs
@@ -96,12 +96,12 @@ namespace VSColorOutput.Output.BuildEvents
 
             if (ShowBuildReport)
             {
-                buildOutputPane.OutputString("\r\nProjects build report:\r\n");
-                buildOutputPane.OutputString("  Status    | Project [Config|platform]\r\n");
-                buildOutputPane.OutputString(" -----------|---------------------------------------------------------------------------------------------------\r\n");
+                buildOutputPane.OutputString($"{Environment.NewLine}Projects build report:{Environment.NewLine}");
+                buildOutputPane.OutputString($"  Status    | Project [Config|platform]{Environment.NewLine}");
+                buildOutputPane.OutputString($" -----------|---------------------------------------------------------------------------------------------------{Environment.NewLine}");
                 foreach (var reportItem in _projectsBuildReport)
                 {
-                    buildOutputPane.OutputString(reportItem + "\r\n");
+                    buildOutputPane.OutputString(reportItem + Environment.NewLine);
                 }
             }
 
@@ -110,20 +110,20 @@ namespace VSColorOutput.Output.BuildEvents
                 var now = DateTime.Now;
                 var elapsed = now - _buildStartTime;
                 var time = elapsed.ToString(@"hh\:mm\:ss\.fff");
-                var buildTime = now.ToString("yyyy-MM-dd hh:mm:ss tt", new CultureInfo("en-US"));
-                var text = $"Time Elapsed {time}";
-                var text2 = $"Build ended at {buildTime}";
-                buildOutputPane.OutputString("\r\n" + text + "\r\n");
-                buildOutputPane.OutputString(text2 + "\r\n");
+                var buildTime = now.ToString(CultureInfo.CurrentCulture);
+                var timeElapsed = $"Time Elapsed {time} (hh:mm:ss.fff)";
+                var endedAt = $"Build ended at {buildTime}";
+                buildOutputPane.OutputString($"{Environment.NewLine}{timeElapsed}{Environment.NewLine}");
+                buildOutputPane.OutputString($"{endedAt}{Environment.NewLine}");
             }
 
             if (ShowDonation)
             {
-                buildOutputPane.OutputString("\r\n++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
-                buildOutputPane.OutputString("\r\n+++                 Please consider donating to VSColorOutput                    +++");
-                buildOutputPane.OutputString("\r\n+++                       https://mike-ward.net/donate/                          +++");
-                buildOutputPane.OutputString("\r\n+++            (this message can be turned off in the settings panel)            +++");
-                buildOutputPane.OutputString("\r\n++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\r\n");
+                buildOutputPane.OutputString($"{Environment.NewLine}++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+                buildOutputPane.OutputString($"{Environment.NewLine}+++                 Please consider donating to VSColorOutput                    +++");
+                buildOutputPane.OutputString($"{Environment.NewLine}+++                       https://mike-ward.net/donate/                          +++");
+                buildOutputPane.OutputString($"{Environment.NewLine}+++            (this message can be turned off in the settings panel)            +++");
+                buildOutputPane.OutputString($"{Environment.NewLine}++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++{Environment.NewLine}");
             }
         }
 
@@ -137,7 +137,7 @@ namespace VSColorOutput.Output.BuildEvents
 
             if (ShowBuildReport)
             {
-                _projectsBuildReport.Add("  " + (success ? "Succeeded" : "Failed   ") + " | " + project + " [" + projectConfig + "|" + platform + "]");
+								_projectsBuildReport.Add("  " + (success ? "Succeeded" : "Failed   ") + $" | {project} [{projectConfig}|{platform}]");
             }
         }
 

--- a/VSColorOutput/Output/ColorClassifier/ClassificationTypeDefinitions.cs
+++ b/VSColorOutput/Output/ColorClassifier/ClassificationTypeDefinitions.cs
@@ -34,8 +34,8 @@ namespace VSColorOutput.Output.ColorClassifier
                 _colorMap = ColorMap.GetMap();
                 _settingsLoaded = true;
             }
-            Color color;
-            if (!_colorMap.TryGetValue(classificationName, out color)) color = Color.Gray;
+            
+            if (!_colorMap.TryGetValue(classificationName, out Color color)) color = Color.Gray;
             return ToMediaColor(color);
         }
 

--- a/VSColorOutput/Output/ColorClassifier/RegExClassification.cs
+++ b/VSColorOutput/Output/ColorClassifier/RegExClassification.cs
@@ -7,19 +7,19 @@ namespace VSColorOutput.Output.ColorClassifier
     {
         private string _regExPattern;
 
-				public RegExClassification() => _regExPattern = ".*";
+        public RegExClassification() => _regExPattern = ".*";
 
-				public string RegExPattern
-				{
-					get => _regExPattern;
-					set
-					{
-						ValidatePattern(value);
-						_regExPattern = value;
-					}
-				}
+        public string RegExPattern
+        {
+          get => _regExPattern;
+          set
+          {
+            ValidatePattern(value);
+            _regExPattern = value;
+          }
+        }
 
-		public ClassificationTypes ClassificationType { get; set; }
+    public ClassificationTypes ClassificationType { get; set; }
         public bool IgnoreCase { get; set; }
 
         public override string ToString()

--- a/VSColorOutput/Output/ColorClassifier/RegExClassification.cs
+++ b/VSColorOutput/Output/ColorClassifier/RegExClassification.cs
@@ -7,22 +7,19 @@ namespace VSColorOutput.Output.ColorClassifier
     {
         private string _regExPattern;
 
-        public RegExClassification()
-        {
-            _regExPattern = ".*";
-        }
+				public RegExClassification() => _regExPattern = ".*";
 
-        public string RegExPattern
-        {
-            get { return _regExPattern; }
-            set
-            {
-                ValidatePattern(value);
-                _regExPattern = value;
-            }
-        }
+				public string RegExPattern
+				{
+					get => _regExPattern;
+					set
+					{
+						ValidatePattern(value);
+						_regExPattern = value;
+					}
+				}
 
-        public ClassificationTypes ClassificationType { get; set; }
+		public ClassificationTypes ClassificationType { get; set; }
         public bool IgnoreCase { get; set; }
 
         public override string ToString()

--- a/VSColorOutput/Output/TimeStamp/TimeStampVisual.cs
+++ b/VSColorOutput/Output/TimeStamp/TimeStampVisual.cs
@@ -17,9 +17,9 @@ namespace VSColorOutput.Output.TimeStamp
 
         public object LineTag { get; private set; }
 
-				public TimeStampVisual() => SnapsToDevicePixels = true;
+        public TimeStampVisual() => SnapsToDevicePixels = true;
 
-				protected override void OnRender(DrawingContext drawingContext)
+        protected override void OnRender(DrawingContext drawingContext)
         {
             drawingContext.DrawText(_formattedText, new Point(_horizontalOffset, _verticalOffset));
         }

--- a/VSColorOutput/Output/TimeStamp/TimeStampVisual.cs
+++ b/VSColorOutput/Output/TimeStamp/TimeStampVisual.cs
@@ -17,12 +17,9 @@ namespace VSColorOutput.Output.TimeStamp
 
         public object LineTag { get; private set; }
 
-        public TimeStampVisual()
-        {
-            SnapsToDevicePixels = true;
-        }
+				public TimeStampVisual() => SnapsToDevicePixels = true;
 
-        protected override void OnRender(DrawingContext drawingContext)
+				protected override void OnRender(DrawingContext drawingContext)
         {
             drawingContext.DrawText(_formattedText, new Point(_horizontalOffset, _verticalOffset));
         }


### PR DESCRIPTION
ElapsedBuildTime is now aware of the current culture,
Some variables renamed in BuildEvents.cs,
replaced \r\n with Environment.NewLine

Introduced some c# 6/7 language features:
-  c# 6 expression-bodied members for get-only indexers
-  c# 6 expression-bodied members for get-only properties
-  c# 7 expression-bodied members for ctors
-  c# 7 expression-bodied members for get accessors
-  c# 7 out variable in method invocation
