### PR TITLE
Add parentheses to Time Stamp Difference

### DIFF
--- a/VSColorOutput/Output/TimeStamp/TimeStampMargin.cs
+++ b/VSColorOutput/Output/TimeStamp/TimeStampMargin.cs
@@ -205,7 +205,7 @@ namespace VSColorOutput.Output.TimeStamp
                 var differenceText = string.IsNullOrWhiteSpace(_differenceTimeFormat) ? string.Empty : difference.ToString(_differenceTimeFormat);
 
                 return elapsedText
-                    + (string.IsNullOrWhiteSpace(differenceText) ? string.Empty : $" {differenceText}");
+                    + (string.IsNullOrWhiteSpace(differenceText) ? string.Empty : $" ({differenceText})");
             }
             catch (Exception)
             {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16515307/70582271-41a17e80-1bfd-11ea-8f07-787ebe456030.png)

After updating to 2.7, parentheses on `Time Stamp Difference` are missing.