### PR TITLE
Minor tweak to the error matching regex to handle the /errorReport option for cl.exe

### DIFF
--- a/VSColorOutput.Tests/OutputClassifierTests.cs
+++ b/VSColorOutput.Tests/OutputClassifierTests.cs
@@ -43,6 +43,7 @@ namespace Tests
         [DataRow("+++>", ClassificationTypeDefinitions.LogCustom1)]
         [DataRow(":Error:", ClassificationTypeDefinitions.LogError)]
         [DataRow("Error ", ClassificationTypeDefinitions.LogError)]
+        [DataRow("/errorReport:prompt ", ClassificationTypeDefinitions.BuildText)]
         [DataRow(" Failed ", ClassificationTypeDefinitions.LogError)]
         [DataRow("Failed ", ClassificationTypeDefinitions.LogError)]
         [DataRow(" Fail ", ClassificationTypeDefinitions.LogError)]

--- a/VSColorOutput/State/Settings.cs
+++ b/VSColorOutput/State/Settings.cs
@@ -178,7 +178,7 @@ namespace VSColorOutput.State
                 },
                 new RegExClassification
                 {
-                    RegExPattern = @"(\W|^)^(?!.*warning\s(BC|CS|CA)\d+:).*(error|fail|failed|exception)[^\w\.\-\+]",
+                    RegExPattern = @"(\W|^)^(?!.*warning\s(BC|CS|CA)\d+:).*((?<!/)error|fail|failed|exception)[^\w\.\-\+]",
                     ClassificationType = ClassificationTypes.LogError,
                     IgnoreCase = true
                 },


### PR DESCRIPTION
Add a small tweak to the regex for categorizing errors to not tip on the cl.exe /errorReport option.

This  command line option is present when CMake is used to configure a Visual Studio project.  Prior to this fix every cl line would be displayed in red.