### PR TITLE
Add VS 2022 support

### DIFF
--- a/VSColorOutput.Tests/VSColorOutput.Tests.csproj
+++ b/VSColorOutput.Tests/VSColorOutput.Tests.csproj
@@ -74,7 +74,7 @@
       <Version>5.10.2</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>16.0.204</Version>
+      <Version>17.0.31902.203</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.UnitTestLibrary">
       <Version>14.3.25407</Version>

--- a/VSColorOutput/Output/GCCErrorList/GCCErrorGenerator.cs
+++ b/VSColorOutput/Output/GCCErrorList/GCCErrorGenerator.cs
@@ -87,7 +87,7 @@ namespace VSColorOutput.Output.GCCErrorList
 
         private static void TaskOnNavigate(object sender, EventArgs eventArgs)
         {
-            var task = sender as Task;
+            var task = sender as TaskListItem;
             if (task == null) throw new ArgumentException("sender");
             task.Line++; // Navigation starts counting from 1, do ++
             _errorListProvider.Navigate(task, new Guid(Constants.vsViewKindCode));

--- a/VSColorOutput/VSColorOutput.csproj
+++ b/VSColorOutput/VSColorOutput.csproj
@@ -96,10 +96,10 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.204" ExcludeAssets="runtime">
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.31902.203" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.5.2044">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.5232">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/VSColorOutput/source.extension.vsixmanifest
+++ b/VSColorOutput/source.extension.vsixmanifest
@@ -11,6 +11,9 @@
     </Metadata>
     <Installation>
         <InstallationTarget Version="[16.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
This change adds VS 2022 support.

Notes:

- I couldn't get the solution to build in VS 2022 with `Microsoft.VisualStudio.SDK` 16.0.204, upgrading to `17.0.31902.203` solved the issue (I was hitting the error described in [this issue](https://github.com/dotnet/sdk/issues/12421))

- VS 2022 is an amd64 binary, which is why I added a new InstallationTarget with that architecture 